### PR TITLE
Adds support for the 'Multilist with Search' field type.

### DIFF
--- a/Reports/Viewers/ItemViewer.cs
+++ b/Reports/Viewers/ItemViewer.cs
@@ -341,6 +341,7 @@ namespace ASR.Reports.Items
                         break;
                     case "checklist":
                     case "multilist":
+                    case "multilist with search":
                     case "treelist":
                     case "treelistex":
                         var multilistField = (MultilistField)field;


### PR DESCRIPTION
The current implementation of the Item Viewer does not support the Multilist with Search field type. This adds support for that field type.
